### PR TITLE
Initialize the callback data earlier in tlog_es_json_refill_array

### DIFF
--- a/lib/es_json_reader.c
+++ b/lib/es_json_reader.c
@@ -333,6 +333,11 @@ tlog_es_json_reader_refill_array(struct tlog_es_json_reader *es_json_reader)
     assert(tlog_es_json_reader_is_valid(
                     (struct tlog_json_reader *)es_json_reader));
 
+    /* Initialize callback data */
+    data.tok = es_json_reader->tok;
+    data.rc = json_tokener_success;
+    data.obj = NULL;
+
     /* Free the previous array, if any */
     if (es_json_reader->array != NULL) {
         json_object_put(es_json_reader->array);
@@ -354,9 +359,6 @@ tlog_es_json_reader_refill_array(struct tlog_es_json_reader *es_json_reader)
     }
 
     /* Set callback data */
-    data.tok = es_json_reader->tok;
-    data.rc = json_tokener_success;
-    data.obj = NULL;
     rc = curl_easy_setopt(es_json_reader->curl, CURLOPT_WRITEDATA, &data);
     if (rc != CURLE_OK) {
         grc = TLOG_GRC_FROM(curl, rc);


### PR DESCRIPTION
Fixes a potential invalid memory access. Found by clang-analyzer.

Addresses:
```c
../../lib/es_json_reader.c:400:18: warning: The left operand of '!=' is a garbage value
    if (data.obj != NULL) {
        ~~~~~~~~ ^
```